### PR TITLE
Fork module to enable AWSSM password management

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -170,7 +170,7 @@ resource "aws_rds_cluster" "secondary" {
   cluster_identifier                  = var.cluster_identifier == "" ? module.this.id : var.cluster_identifier
   database_name                       = var.db_name
   master_username                     = local.ignore_admin_credentials ? null : var.admin_user
-  master_password                     = local.ignore_admin_credentials ? null : var.admin_password
+  master_password                     = local.ignore_admin_credentials ? null : (var.managed_root_password ? null : var.admin_password)
   backup_retention_period             = var.retention_period
   preferred_backup_window             = var.backup_window
   copy_tags_to_snapshot               = var.copy_tags_to_snapshot
@@ -195,6 +195,8 @@ resource "aws_rds_cluster" "secondary" {
   iam_roles                           = var.iam_roles
   backtrack_window                    = var.backtrack_window
   enable_http_endpoint                = local.is_serverless && var.enable_http_endpoint
+  
+  manage_master_user_password         = var.managed_root_password
 
   depends_on = [
     aws_db_subnet_group.default,

--- a/variables.tf
+++ b/variables.tf
@@ -514,3 +514,10 @@ variable "enable_global_write_forwarding" {
   default     = false
   description = "Set to `true`, to forward writes to an associated global cluster."
 }
+
+variable "managed_root_password" {
+  type        = bool
+  default     = false
+  description = "Set to `true` to have the module manage the root password"
+  
+}


### PR DESCRIPTION
## what

Fork the cloudposse module to allow AWS Secrets Manager to manage the master user password

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

Our old way required us to keep root credentials in terraform state which was identified as a major security issue

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
